### PR TITLE
fix: resolve GitHub Action permissions issue for npm publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,6 +46,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      id-token: write
     
     steps:
     - name: Checkout code
@@ -85,13 +88,25 @@ jobs:
         
     - name: Create Git tag
       if: steps.version-check.outputs.version-changed == 'true'
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git tag v${{ steps.version-check.outputs.current-version }}
-        git push origin v${{ steps.version-check.outputs.current-version }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const tag = `v${{ steps.version-check.outputs.current-version }}`;
+          try {
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${tag}`,
+              sha: context.sha
+            });
+            console.log(`Created tag ${tag}`);
+          } catch (error) {
+            if (error.status === 422) {
+              console.log(`Tag ${tag} already exists`);
+            } else {
+              throw error;
+            }
+          }
         
     - name: Skip publish (no version change)
       if: steps.version-check.outputs.version-changed == 'false'


### PR DESCRIPTION
- Add explicit permissions: contents: write, id-token: write
- Replace git push with github-script action for tag creation
- Handles tag creation via GitHub API instead of git push
- Fixes 403 permission denied error for github-actions[bot]
- Resolves exit code 128 issue in publishing workflow