### PR TITLE
fix: enable npx @wangkanai/devops-mcp scoped package execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@wangkanai/devops-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Dynamic Azure DevOps MCP Server for directory-based environment switching",
   "main": "dist/index.js",
-  "bin": "dist/index.js",
+  "bin": {
+    "devops-mcp": "dist/index.js",
+    "wangkanai-devops-mcp": "dist/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
@@ -59,8 +62,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.16.0",
-    "@wangkanai/devops-mcp": "^1.1.0"
+    "@modelcontextprotocol/sdk": "^1.16.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.15",


### PR DESCRIPTION
## Summary
Fixes #17 - NPX Scoped Package Execution Fails

This PR enables the preferred `npx @wangkanai/devops-mcp` syntax while maintaining backwards compatibility.

## Problem
- Users trying `npx @wangkanai/devops-mcp` got "command not found" error
- Only `npx devops-mcp` worked due to binary name resolution issues

## Solution - Hybrid Approach
- Changed `package.json` bin from string to object format with dual binary names:
  ```json
  "bin": {
    "devops-mcp": "dist/index.js",
    "wangkanai-devops-mcp": "dist/index.js"
  }
  ```
- Removed circular dependency issue
- Updated version to 1.2.1 for release

## Commands That Will Work After This Fix
✅ `npx @wangkanai/devops-mcp` (user's preferred - now works\!)  
✅ `npx devops-mcp` (backwards compatible)  
✅ `npx wangkanai-devops-mcp` (direct binary name)  
✅ `claude mcp add devops-mcp -- npx @wangkanai/devops-mcp` (Claude integration)  

## Test Plan
- [ ] Verify GitHub Action npm-publish.yml triggers successfully
- [ ] Test published package with `npx @wangkanai/devops-mcp`
- [ ] Confirm backwards compatibility with `npx devops-mcp`
- [ ] Validate Claude MCP integration works

## Technical Details
- Follows Microsoft's `@azure-devops/mcp` pattern (uses `mcp-server-azuredevops` binary)
- Non-breaking change - adds new binary option while keeping existing
- NPX resolution: `@wangkanai/devops-mcp` → fallback to `wangkanai-devops-mcp` → success

Closes #17