### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,16 @@
+# These are supported funding model platforms
+
+github: wangkanai
+patreon: wangkanai
+open_collective: wangkanai
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+


### PR DESCRIPTION
This pull request adds a new funding configuration file to the repository, enabling support for multiple funding platforms.

### Funding configuration added:
* [`.github/FUNDING.yml`](diffhunk://#diff-07985fdcade0e64d11482724879a644f07879ba61b8fb6c6119e1b1902b72ae4R1-R16): Introduced a funding configuration file that lists supported funding platforms, such as GitHub Sponsors, Patreon, Open Collective, and others. Placeholder entries are included for platforms like Ko-fi, Tidelift, and Buy Me a Coffee, allowing maintainers to customize as needed.