### PR TITLE
Fix GitHub issue #45 - Comment API version requires preview flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wangkanai/devops-mcp",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Dynamic Azure DevOps MCP Server for directory-based environment switching",
   "main": "dist/index.js",
   "bin": {

--- a/src/handlers/tool-handlers.ts
+++ b/src/handlers/tool-handlers.ts
@@ -817,8 +817,8 @@ export class ToolHandlers {
         text: args.comment
       };
 
-      // Use API version 6.0 for comments to avoid preview version issues
-      const endpoint = `/wit/workitems/${args.id}/comments?api-version=6.0`;
+      // Use API version 6.0-preview for comments - required for work item comments endpoint
+      const endpoint = `/wit/workitems/${args.id}/comments?api-version=6.0-preview`;
       console.log(`[DEBUG] Adding comment to work item ${args.id} with endpoint: ${endpoint}`);
       
       const result = await this.makeApiRequest(


### PR DESCRIPTION
## Summary
Resolves GitHub issue #45 by fixing the API version requirement for work item comments.

• **Problem**: `add-work-item-comment` command failing with API version error
• **Root Cause**: Azure DevOps comments endpoint requires preview flag (`6.0-preview`) 
• **Solution**: Changed API version from `6.0` to `6.0-preview`

## Changes Made

### 1. API Version Fix
- **File**: `src/handlers/tool-handlers.ts`
- **Change**: Updated endpoint from `api-version=6.0` to `api-version=6.0-preview`
- **Line**: 821 - Comments endpoint construction
- **Impact**: Work item comments can now be added successfully

### 2. Documentation Update
- **Updated comment**: Clarified that preview version is required for comments endpoint
- **Removed**: Misleading comment about "avoiding preview version issues"

### 3. Version Update
- **Changed**: Package version from `1.5.5` → `1.5.6` (patch increment)

## Technical Details

**Azure DevOps API Requirement**: The work item comments endpoint specifically requires the `-preview` flag in the API version, unlike other work item operations that use stable versions.

**Error Fixed**:
```
The requested version '6.0' of the resource is under preview. 
The -preview flag must be supplied in the api-version for such requests.
```

**Before**:
```typescript
const endpoint = `/wit/workitems/${args.id}/comments?api-version=6.0`;
```

**After**:
```typescript  
const endpoint = `/wit/workitems/${args.id}/comments?api-version=6.0-preview`;
```

## Test Plan
- [x] Verify comment addition works with preview API version
- [x] Confirm no impact on other work item operations
- [x] Validate package version increment

## Impact
- ✅ All work item comment operations now function correctly
- ✅ No breaking changes to existing functionality
- ✅ Backward compatible with all other endpoints

Fixes #45