### PR TITLE
Fix GitHub issue #48 - Enhanced field name resolution for Microsoft.VSTS fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wangkanai/devops-mcp",
-  "version": "1.5.6",
+  "version": "1.5.8",
   "description": "Dynamic Azure DevOps MCP Server for directory-based environment switching",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

Fixes GitHub issue #48 by implementing enhanced field name resolution that explicitly preserves Microsoft.VSTS fields and prevents incorrect System. prefix corruption.

### Problem Resolved
- Microsoft.VSTS fields were potentially getting incorrectly prefixed with "System." causing TF51535 errors
- Example: `Microsoft.VSTS.Common.BusinessValue` → `System.Microsoft.VSTS.Common.BusinessValue` (❌ WRONG)

### Solution Implemented
Enhanced field name resolution with explicit conditional guards:

1. **Microsoft.VSTS fields**: Explicitly preserved exactly as-is (never modified)
2. **System. fields**: Preserved exactly as-is (never double-prefixed)  
3. **Simple system fields**: Get correct System. prefix only when needed
4. **Custom namespaced fields**: Preserved exactly as-is

### Code Changes
- Enhanced `updateWorkItem` field name resolution logic in `src/handlers/tool-handlers.ts`
- Added explicit `Microsoft.VSTS.` and `System.` prefix detection
- Implemented defensive programming approach with clear conditional logic
- Version bump to 1.5.8

### Fields Now Properly Supported
✅ `Microsoft.VSTS.Common.BusinessValue`  
✅ `Microsoft.VSTS.Common.Priority`  
✅ `Microsoft.VSTS.Common.ValueArea`  
✅ `Microsoft.VSTS.Scheduling.StartDate`  
✅ `Microsoft.VSTS.Scheduling.FinishDate`  
✅ `Microsoft.VSTS.Common.Effort`  
✅ All other advanced Agile process fields

### Impact
- Restores full enterprise functionality for advanced work item management
- Enables proper epic planning, sprint planning, and lifecycle management
- Eliminates TF51535 field resolution errors
- Maintains backward compatibility

## Test Plan

- [x] Enhanced field name resolution logic verified with comprehensive test cases
- [x] Build successful with no compilation errors  
- [x] All Microsoft.VSTS fields confirmed to preserve exact naming
- [x] System. fields confirmed to avoid double-prefixing
- [x] Custom namespaced fields confirmed to remain unchanged

**Ready for merge** ✅