### PR TITLE
fix: add setup-node with registry-url to fix npm publish auth

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,12 +61,18 @@ jobs:
         git checkout --detach FETCH_HEAD
         git log --oneline -1
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        registry-url: 'https://registry.npmjs.org'
+
     - name: Show tool versions
       run: |
         node --version
         npm --version
         gh --version
-        
+
     - name: Install dependencies
       run: npm ci
       


### PR DESCRIPTION
## Summary
- The publish job set `NODE_AUTH_TOKEN` but had no `.npmrc` to map it to the npm registry, causing `ENEEDAUTH` errors
- Added `actions/setup-node@v4` with `registry-url: 'https://registry.npmjs.org'` which auto-creates the `.npmrc` file that maps `NODE_AUTH_TOKEN` to registry authentication

## Test plan
- [ ] Verify the publish workflow succeeds on merge to main
- [ ] Confirm npm package is published with correct authentication